### PR TITLE
feat: Allow opting out from excluding the aws sdk

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
+  clearMocks: true,
   collectCoverage: true,
   coverageThreshold: {
     global: {

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -35,11 +35,7 @@ const main = async () => {
     outdir: path.resolve(process.cwd(), outdir),
     node,
     cwd: process.cwd(),
-    esbuild: includeAwsSdk
-      ? {
-          external: [],
-        }
-      : undefined,
+    includeAwsSdk,
   });
 };
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -4,7 +4,9 @@ import * as yargs from 'yargs';
 import { bundle } from '../bundle';
 
 const main = async () => {
-  const { entries, outdir, node } = await yargs(process.argv.slice(2))
+  const { entries, outdir, node, includeAwsSdk } = await yargs(
+    process.argv.slice(2),
+  )
     .option('entries', {
       type: 'string',
       description: 'The lambda entrypoints to bundle. Can be a glob pattern.',
@@ -20,6 +22,11 @@ const main = async () => {
       description: 'The Node version to target.',
       demandOption: true,
     })
+    .option('include-aws-sdk', {
+      type: 'boolean',
+      description: 'Allow opting out from excluding the aws sdk',
+      default: false,
+    })
     .strict()
     .parse();
 
@@ -28,6 +35,11 @@ const main = async () => {
     outdir: path.resolve(process.cwd(), outdir),
     node,
     cwd: process.cwd(),
+    esbuild: includeAwsSdk
+      ? {
+          external: [],
+        }
+      : undefined,
   });
 };
 

--- a/src/bundle.test.ts
+++ b/src/bundle.test.ts
@@ -49,6 +49,37 @@ test('bundle passes the correct arguments to build(...)', async () => {
   );
 });
 
+test('bundle allows for overriding esbuild options build(...)', async () => {
+  writeTestInputFile('first-file.js', `export const TMP = 'TMP';`);
+  await bundle({
+    entries: `${TEST_INPUT_DIR}/first-file.js`,
+    outdir: TEST_OUTPUT_DIR,
+    node: 15,
+    esbuild: {
+      target: 'node19',
+      external: [],
+      alias: {
+        oldpackage: 'newpackage',
+      },
+    },
+  });
+
+  expect(build).toHaveBeenCalledTimes(1);
+  expect(build).toHaveBeenCalledWith(
+    expect.objectContaining({
+      bundle: true,
+      sourcemap: false,
+      platform: 'node',
+      target: 'node19',
+      external: [],
+      resolveExtensions: ['.jsx', '.js', '.tsx', '.ts', '.json'],
+      alias: {
+        oldpackage: 'newpackage',
+      },
+    }),
+  );
+});
+
 test('bundle handles the cwd parameter', async () => {
   writeTestInputFile('first-file.js', `export const TMP = 'TMP';`);
   await bundle({

--- a/src/bundle.test.ts
+++ b/src/bundle.test.ts
@@ -49,37 +49,6 @@ test('bundle passes the correct arguments to build(...)', async () => {
   );
 });
 
-test('bundle allows for overriding esbuild options build(...)', async () => {
-  writeTestInputFile('first-file.js', `export const TMP = 'TMP';`);
-  await bundle({
-    entries: `${TEST_INPUT_DIR}/first-file.js`,
-    outdir: TEST_OUTPUT_DIR,
-    node: 15,
-    esbuild: {
-      target: 'node19',
-      external: [],
-      alias: {
-        oldpackage: 'newpackage',
-      },
-    },
-  });
-
-  expect(build).toHaveBeenCalledTimes(1);
-  expect(build).toHaveBeenCalledWith(
-    expect.objectContaining({
-      bundle: true,
-      sourcemap: false,
-      platform: 'node',
-      target: 'node19',
-      external: [],
-      resolveExtensions: ['.jsx', '.js', '.tsx', '.ts', '.json'],
-      alias: {
-        oldpackage: 'newpackage',
-      },
-    }),
-  );
-});
-
 test('bundle handles the cwd parameter', async () => {
   writeTestInputFile('first-file.js', `export const TMP = 'TMP';`);
   await bundle({
@@ -284,6 +253,28 @@ test('bundle works with an array of entries', async () => {
 });
 
 describe('AWS SDK bundling behavior', () => {
+  test('allows for ignoring AWS SDK exclusion behavior', async () => {
+    writeTestInputFile('first-file.js', `export const TMP = 'TMP';`);
+    await bundle({
+      entries: `${TEST_INPUT_DIR}/first-file.js`,
+      outdir: TEST_OUTPUT_DIR,
+      node: 15,
+      includeAwsSdk: true,
+    });
+
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(build).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bundle: true,
+        sourcemap: false,
+        platform: 'node',
+        target: 'node15',
+        external: [],
+        resolveExtensions: ['.jsx', '.js', '.tsx', '.ts', '.json'],
+      }),
+    );
+  });
+
   /** Bundles the code, returning the output. */
   const bundleCode = async (params: {
     node: number;

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -24,6 +24,11 @@ export type BundleOptions = {
   cwd?: string;
 
   /**
+   * Allows for opting out from excluding the aws sdk
+   */
+  includeAwsSdk?: boolean;
+
+  /**
    * Override options to pass to esbuild. These override any options generated
    * by other internal settings.
    *
@@ -38,6 +43,7 @@ export const bundle = async ({
   outdir,
   node: nodeVersion,
   cwd,
+  includeAwsSdk = false,
   esbuild,
 }: BundleOptions) => {
   const entryPoints = (typeof entries === 'string' ? [entries] : entries)
@@ -61,7 +67,11 @@ export const bundle = async ({
        *
        * https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/
        */
-      external: nodeVersion >= 18 ? ['@aws-sdk/*'] : ['aws-sdk'],
+      external: includeAwsSdk
+        ? []
+        : nodeVersion >= 18
+        ? ['@aws-sdk/*']
+        : ['aws-sdk'],
       /**
        * As of v0.14.44, esbuild by default prefers .ts over .js files.
        *


### PR DESCRIPTION
## Motivation

While blamda is a tool for bundling lambdas in some cases it could be helpful to allow it to opt out of the behavior where it excludes the aws sdk. For example, when a service repo is using blamda to bundle the service, but then a task is added that interacts with the aws sdk and blamda is used to bundle it because its readily available - only to find the sdk is not available when the task goes to run

here is a case where something like that happened

https://lifeomic.slack.com/archives/C04VA1L769K/p1680283732759199
https://github.com/lifeomic/cost-reporting/pull/198