### PR TITLE
feat: new option artifactPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ bundle({
 });
 ```
 
+### Build for Synthetics Canary
+
+When deploying a lambda as Synthetics Canary, it requires the packaged js file
+saved under `nodejs/node_modules` within the packaged zip file. Please use the
+option `artifactPrefix` to specify the directory structure within the packaged
+zip file:
+
+```bash
+yarn blamda --entries src/my-service.ts --outdir build-output \
+--artifact-prefix "nodejs/node_modules" --node 14
+```
+
+The output:
+
+```
+build-output/
+  my-service.zip # Upload this to Synthetics Canary!
+  my-service/    # Or, package + upload this directory yourself.
+    nodejs/
+      node_modules/
+        my-service.js
+```
+
 ## Why Use This
 
 As a pattern, bundling Lambda code provides a handful of benefits, especially in an

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -4,7 +4,7 @@ import * as yargs from 'yargs';
 import { bundle } from '../bundle';
 
 const main = async () => {
-  const { entries, outdir, node, includeAwsSdk } = await yargs(
+  const { entries, outdir, node, includeAwsSdk, artifactPrefix } = await yargs(
     process.argv.slice(2),
   )
     .option('entries', {
@@ -27,6 +27,11 @@ const main = async () => {
       description: 'Allow opting out from excluding the aws sdk',
       default: false,
     })
+    .option('artifact-prefix', {
+      type: 'string',
+      description: 'The artifact prefix within the built zip file',
+      default: '',
+    })
     .strict()
     .parse();
 
@@ -36,6 +41,7 @@ const main = async () => {
     node,
     cwd: process.cwd(),
     includeAwsSdk,
+    artifactPrefix,
   });
 };
 

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -29,6 +29,11 @@ export type BundleOptions = {
   includeAwsSdk?: boolean;
 
   /**
+   * the output directories of build artifact.
+   */
+  artifactPrefix?: string;
+
+  /**
    * Override options to pass to esbuild. These override any options generated
    * by other internal settings.
    *
@@ -50,6 +55,7 @@ export const bundle = async ({
   node: nodeVersion,
   cwd,
   includeAwsSdk = false,
+  artifactPrefix = '',
   esbuild: { external = [], ...esbuild } = {},
 }: BundleOptions) => {
   const entryPoints = (typeof entries === 'string' ? [entries] : entries)
@@ -104,11 +110,11 @@ export const bundle = async ({
 
   await Promise.all(
     outFilenames.map(async (filename) => {
-      const dest = `${outdir}/${filename}`;
+      const dest = `${outdir}/${filename}/${artifactPrefix}`;
       // Make a single directory for the artifacts
       await fs.mkdir(dest, { recursive: true });
       // Move the bundle into the directory
-      await fs.rename(`${dest}.js`, `${dest}/${filename}.js`);
+      await fs.rename(`${outdir}/${filename}.js`, `${dest}/${filename}.js`);
     }),
   );
 


### PR DESCRIPTION
This is for deploying to synthetics canary that requires the packaged script saved into **`nodejs/node_modules`**. see the official doc [Packaging your canary files](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_WritingCanary_Nodejs.html#CloudWatch_Synthetics_Canaries_package).

e.g.,

```
build-output/
  my-service/
    nodejs/
      node_modules/
        my-service.js
```

