### PR TITLE
Proposal: always include AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,3 @@ environment with "many deploys":
   - Reduced cost of S3 storage of code artifacts, thanks to smaller file size.
 
 - Provides an opportunity to make easy Lambda environment-specific optimizations.
-  - e.g. the `aws-sdk` module is "built-in" in to the Lambda environment. We can avoid
-    bundling it and therefore significantly reduce bundle size.

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -4,7 +4,7 @@ import * as yargs from 'yargs';
 import { bundle } from '../bundle';
 
 const main = async () => {
-  const { entries, outdir, node, includeAwsSdk, artifactPrefix } = await yargs(
+  const { entries, outdir, node, artifactPrefix } = await yargs(
     process.argv.slice(2),
   )
     .option('entries', {
@@ -22,11 +22,6 @@ const main = async () => {
       description: 'The Node version to target.',
       demandOption: true,
     })
-    .option('include-aws-sdk', {
-      type: 'boolean',
-      description: 'Allow opting out from excluding the aws sdk',
-      default: false,
-    })
     .option('artifact-prefix', {
       type: 'string',
       description: 'The artifact prefix within the built zip file',
@@ -40,7 +35,6 @@ const main = async () => {
     outdir: path.resolve(process.cwd(), outdir),
     node,
     cwd: process.cwd(),
-    includeAwsSdk,
     artifactPrefix,
   });
 };


### PR DESCRIPTION
## Motivation
I'd like to propose _modifying_ the behavior of this tool to start _including_ the AWS SDK in bundles.

**Why**
- Generally, the v3 SDK is smaller than the v2 SDK, since it is modular. So, the size tradeoff is less powerful.

- In the past few months, we've seen a few issues resulting from the "built-in" version of the SDK being different from the version locked in the project. By bundling the project version, we can be more certain that deployed behavior will match local behavior in tests.