### PR TITLE
feat: new argument --external

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,8 @@ bundle({
 });
 ```
 
-Notice that it could specify esbuild cli argument `--external` by using blamda CLI.
+Or using blamda CLI:
+
+```SHELL
+blamda --entries=src/*Lambda.ts --external=dtrace-provider
+```

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -5,36 +5,41 @@ import * as yargs from 'yargs';
 import { bundle } from '../bundle';
 
 const main = async () => {
-  const { entries, outdir, node, includeAwsSdk, artifactPrefix } = await yargs(
-    process.argv.slice(2),
-  )
-    .option('entries', {
-      type: 'string',
-      description: 'The lambda entrypoints to bundle. Can be a glob pattern.',
-      demandOption: true,
-    })
-    .option('outdir', {
-      type: 'string',
-      description: 'The output directory for lambda artifacts',
-      demandOption: true,
-    })
-    .option('node', {
-      type: 'number',
-      description: 'The Node version to target.',
-      demandOption: true,
-    })
-    .option('include-aws-sdk', {
-      type: 'boolean',
-      description: 'Allow opting out from excluding the aws sdk',
-      default: false,
-    })
-    .option('artifact-prefix', {
-      type: 'string',
-      description: 'The artifact prefix within the built zip file',
-      default: '',
-    })
-    .strict()
-    .parse();
+  const { entries, outdir, node, includeAwsSdk, artifactPrefix, external } =
+    await yargs(process.argv.slice(2))
+      .option('entries', {
+        type: 'string',
+        description: 'The lambda entrypoints to bundle. Can be a glob pattern.',
+        demandOption: true,
+      })
+      .option('outdir', {
+        type: 'string',
+        description: 'The output directory for lambda artifacts',
+        demandOption: true,
+      })
+      .option('node', {
+        type: 'number',
+        description: 'The Node version to target.',
+        demandOption: true,
+      })
+      .option('include-aws-sdk', {
+        type: 'boolean',
+        description: 'Allow opting out from excluding the aws sdk',
+        default: false,
+      })
+      .option('artifact-prefix', {
+        type: 'string',
+        description: 'The artifact prefix within the built zip file',
+        default: '',
+      })
+      .option('external', {
+        type: 'string',
+        description: 'package name to exclude from the bundle',
+        array: true,
+        default: '',
+      })
+      .strict()
+      .parse();
 
   await bundle({
     entries,
@@ -43,6 +48,9 @@ const main = async () => {
     cwd: process.cwd(),
     includeAwsSdk,
     artifactPrefix,
+    esbuild: {
+      external: Array.isArray(external) ? external : [external],
+    },
   });
 };
 


### PR DESCRIPTION
Follow up of #21

So that it doesn't need to depend on a separate script all the time

it supports using `--external` multiple times.